### PR TITLE
add GO_DOMAIN to install.sh

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -183,14 +183,14 @@ download_binary() {
 	else
 		GO_BINARY_FILE=${VERSION}.${GVM_OS}-${GVM_ARCH}.tar.gz
 	fi
-	GO_BINARY_URL="http://golang.org/dl/${GO_BINARY_FILE}"
+	GO_BINARY_URL="http://${GO_DOMAIN:-golang.org}/dl/${GO_BINARY_FILE}"
 	GO_BINARY_PATH=${GVM_ROOT}/archive/${GO_BINARY_FILE}
 
 	if [ ! -f $GO_BINARY_PATH ]; then
 		curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}
 
 		if [[ $? -ne 0 ]]; then
-			display_error "Failed to download binary go from http://golang.org. Trying https://go.googlecode.com"
+			display_error "Failed to download binary go from http://${GO_DOMAIN:-golang.org}. Trying https://go.googlecode.com"
 			GO_BINARY_URL="https://go.googlecode.com/files/${GO_BINARY_FILE}"
 
 			curl -s -f -L $GO_BINARY_URL > ${GO_BINARY_PATH}


### PR DESCRIPTION
Add GO_DOMAIN to install.sh to specify domain of golang.
In china, the content of https://golang.org can be visit on https://golang.google.cn without vpn now.
And your can specify install go from it by set environment GO_DOMAIN=golang.google.cn